### PR TITLE
Improve helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ pytest
 
 ## Sending a Test Notification
 
-Run the helper script to send a sample message to your Teams channel using the
-configured webhook URL. The script prints a confirmation on success or the
-error message returned if the request fails. The notification payload now
-includes `attachments` under `body` to match the flow's expectations. If no run
-appears in your Power Automate history, double-check the webhook URL and make
-sure your flow is configured to read `triggerBody().body.attachments`.
+Run the helper script to send a sample message to your Teams channel using
+the configured webhook URL. The script prints a confirmation on success or
+the error message returned if the request fails. It looks for a `WEBHOOK_URL`
+environment variable but will fall back to the test value defined in
+`tests/test_monitor.py`. The notification payload now includes `attachments`
+under `body` to match the flow's expectations. If no run appears in your
+Power Automate history, double-check the webhook URL and make sure your flow
+is configured to read `triggerBody().body.attachments`.
 
 ```
 python send_teams_notification.py

--- a/send_teams_notification.py
+++ b/send_teams_notification.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+from monitorlib.monitor import send_webhook_alert
+
+
+def main() -> None:
+    # Prefer the WEBHOOK_URL environment variable but fall back to the
+    # constant used in the tests so the script works out of the box.
+    webhook_url = os.environ.get("WEBHOOK_URL")
+
+    if not webhook_url:
+        try:
+            from tests.test_monitor import WEBHOOK_URL as TEST_WEBHOOK_URL
+        except Exception:
+            TEST_WEBHOOK_URL = None
+        webhook_url = TEST_WEBHOOK_URL
+
+    if not webhook_url:
+        print("Usage: python send_teams_notification.py <webhook_url>")
+        print("Or set WEBHOOK_URL environment variable")
+        sys.exit(1)
+
+    try:
+        send_webhook_alert(
+            webhook_url, "Test Notification", "This is a test message", True
+        )
+    except Exception as exc:
+        print(f"Failed to send notification: {exc}")
+    else:
+        print("Notification sent")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- default to WEBHOOK_URL from tests when sending Teams notification
- document default webhook URL in README

## Testing
- `pytest -q`
- `python send_teams_notification.py` *(fails to send due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6865a146f7ac8320aebbed0c0f4049a8