### PR TITLE
Add API server for service checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,36 @@ is configured to read `triggerBody().body.attachments`.
 python send_teams_notification.py
 ```
 
+
+## Running the API Server
+
+A small Flask application is provided in `api_server.py` to expose the
+`check_services` function over HTTP. Install Flask and then run the server:
+
+```bash
+pip install flask
+python api_server.py  # listens on port 8000
+```
+
+If you prefer the `flask run` command, set the `FLASK_APP` environment
+variable and specify the port:
+
+```bash
+FLASK_APP=api_server.py flask run -p 8000
+```
+
+Send a POST request with the webhook URL and service definitions. Each
+service includes a dotted `module:function` path for its health check.
+
+```bash
+curl -X POST http://localhost:8000/check \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "webhook_url": "<webhook-url>",
+        "services": [
+          {"name": "example_service", "check": "mymodule:ping_api", "alert_on_success": false}
+        ]
+      }'
+```
+
+The API will return a JSON object mapping service names to their status.

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,42 @@
+import os
+from importlib import import_module
+from typing import Any, Callable, List
+
+from flask import Flask, request, jsonify
+
+from monitorlib.monitor import Service, check_services
+
+app = Flask(__name__)
+
+
+def load_callable(path: str) -> Callable[[], Any]:
+    """Load a callable from a ``module:function`` style path."""
+    module_name, func_name = path.split(":", 1)
+    module = import_module(module_name)
+    return getattr(module, func_name)
+
+
+@app.route("/check", methods=["POST"])
+def check() -> Any:
+    data = request.get_json(force=True)
+    services_data = data.get("services", [])
+    webhook_url = data.get("webhook_url")
+
+    services: List[Service] = []
+    for svc in services_data:
+        name = svc["name"]
+        path = svc["check"]
+        alert_on_success = svc.get("alert_on_success", False)
+        health_fn = load_callable(path)
+        services.append(Service(name, health_fn, alert_on_success))
+
+    statuses = check_services(services, webhook_url)
+    return jsonify(statuses)
+
+
+def main() -> None:
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `api_server.py` exposing a `/check` route using Flask
- document how to run the server and example request in README
- clarify port usage and add `flask run` instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686afe2f82f88320b8acfb144e88e456