### PR TITLE
Add API server for service checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,42 @@ is configured to read `triggerBody().body.attachments`.
 python send_teams_notification.py
 ```
 
+
+## Running the API Server
+
+A small Flask application is provided in `api_server.py` to expose the
+`check_services` function over HTTP. Install Flask and then run the server:
+
+```bash
+pip install flask
+python api_server.py  # listens on port 8000
+```
+
+If you prefer the `flask run` command, set the `FLASK_APP` environment
+variable and specify the host and port. Binding to `0.0.0.0` allows
+access from outside the local machine (useful if you're running in WSL
+or a container):
+
+```bash
+FLASK_APP=api_server.py flask run --host 0.0.0.0 -p 8000
+```
+
+Send a POST request with the webhook URL and service definitions. Each
+service includes a dotted `module:function` path for its health check.
+
+```bash
+curl -X POST http://localhost:8000/check \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "webhook_url": "<webhook-url>",
+        "services": [
+          {"name": "example_service", "check": "mymodule:ping_api", "alert_on_success": false}
+        ]
+      }'
+```
+
+Replace `mymodule:ping_api` with the actual path to your health check
+function. If the module or function cannot be imported, the server responds
+with `400 Bad Request` and an error message.
+
+The API will return a JSON object mapping service names to their status.

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,56 @@
+import os
+from importlib import import_module
+from typing import Any, Callable, List
+
+from flask import Flask, request, jsonify
+
+from monitorlib.monitor import Service, check_services
+
+app = Flask(__name__)
+
+
+def load_callable(path: str) -> Callable[[], Any]:
+    """Load a callable from a ``module:function`` style path."""
+    try:
+        module_name, func_name = path.split(":", 1)
+    except ValueError as exc:
+        raise ValueError(f"Invalid callable path '{path}'. Use module:function") from exc
+
+    try:
+        module = import_module(module_name)
+    except Exception as exc:
+        raise ImportError(f"Cannot import module '{module_name}': {exc}") from exc
+
+    try:
+        return getattr(module, func_name)
+    except AttributeError as exc:
+        raise ImportError(f"Module '{module_name}' has no attribute '{func_name}'") from exc
+
+
+@app.route("/check", methods=["POST"])
+def check() -> Any:
+    data = request.get_json(force=True)
+    services_data = data.get("services", [])
+    webhook_url = data.get("webhook_url")
+
+    services: List[Service] = []
+    for svc in services_data:
+        name = svc["name"]
+        path = svc["check"]
+        alert_on_success = svc.get("alert_on_success", False)
+        try:
+            health_fn = load_callable(path)
+        except Exception as exc:
+            return jsonify({"error": str(exc)}), 400
+        services.append(Service(name, health_fn, alert_on_success))
+
+    statuses = check_services(services, webhook_url)
+    return jsonify(statuses)
+
+
+def main() -> None:
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `api_server.py` exposing a `/check` route using Flask
- document how to run the server and example request in README
- clarify port usage and add `flask run` instructions
- mention binding to `0.0.0.0` for access outside localhost
- handle invalid callable paths gracefully with 400 errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686afe2f82f88320b8acfb144e88e456