### PR TITLE
Add simple web UI for monitoring system

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,22 @@ with `400 Bad Request` and an error message.
 
 
 The API will return a JSON object mapping service names to their status.
+
+## Running the UI
+
+`ui_server.py` provides a very small web interface on top of the API.
+It renders a form where you can enter the webhook URL and up to three
+services to check. The UI sends the form data to the API server and
+displays the results in a table.
+
+Start the API server first (listening on port 8000) and then run the
+UI on a different port:
+
+```bash
+pip install flask
+python ui_server.py  # listens on port 5000 by default
+```
+
+Set the `API_URL` environment variable if the API is reachable at a
+different address. The UI will show each service's status after the
+checks complete.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+<head>
+    <title>Service Monitor UI</title>
+    <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 0.5em; }
+    </style>
+</head>
+<body>
+<h1>Service Monitor</h1>
+<form method="post">
+    <div>
+        <label>Webhook URL:<br>
+            <input type="text" name="webhook_url" size="60">
+        </label>
+    </div>
+    <h3>Services</h3>
+    <table>
+        <tr><th>Name</th><th>Check path</th><th>Alert on Success</th></tr>
+        {% for i in range(3) %}
+        <tr>
+            <td><input type="text" name="service_name"></td>
+            <td><input type="text" name="service_check" size="40"></td>
+            <td><input type="checkbox" name="alert_on_success"></td>
+        </tr>
+        {% endfor %}
+    </table>
+    <div>
+        <button type="submit">Run Checks</button>
+    </div>
+</form>
+{% if error %}
+<p style="color: red;">Error: {{ error }}</p>
+{% endif %}
+{% if results %}
+<h3>Results</h3>
+<table>
+    <tr><th>Service</th><th>Status</th><th>Message</th></tr>
+    {% for name, info in results.items() %}
+    <tr>
+        <td>{{ name }}</td>
+        <td>{{ 'UP' if info.healthy else 'DOWN' }}</td>
+        <td>{{ info.message }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+</body>
+</html>

--- a/ui_server.py
+++ b/ui_server.py
@@ -1,0 +1,45 @@
+import os
+import json
+from typing import List, Dict, Any
+from flask import Flask, render_template, request
+import urllib.request
+
+# URL of the monitoring API server
+API_URL = os.environ.get("API_URL", "http://localhost:8000/check")
+
+app = Flask(__name__)
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    results = None
+    error = None
+    if request.method == "POST":
+        webhook_url = request.form.get("webhook_url")
+        service_names = request.form.getlist("service_name")
+        service_checks = request.form.getlist("service_check")
+        alert_flags = request.form.getlist("alert_on_success")
+
+        services: List[Dict[str, Any]] = []
+        for name, check, alert in zip(service_names, service_checks, alert_flags):
+            if name and check:
+                services.append({
+                    "name": name,
+                    "check": check,
+                    "alert_on_success": alert == "on",
+                })
+
+        payload = json.dumps({"webhook_url": webhook_url, "services": services}).encode("utf-8")
+        req = urllib.request.Request(API_URL, data=payload, headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req) as resp:
+                results = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:
+            error = str(exc)
+
+    return render_template("index.html", results=results, error=error)
+
+def main() -> None:
+    app.run(host="0.0.0.0", port=int(os.environ.get("UI_PORT", 5000)))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Flask-based UI server to interact with the monitoring API
- add HTML template to display health check results
- document how to run the UI in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686b46248f488320a0591f5f457b3387